### PR TITLE
Do not export immutable fields

### DIFF
--- a/services/core-store.js
+++ b/services/core-store.js
@@ -96,6 +96,9 @@ module.exports = {
       const shouldExclude = strapi.plugins['config-sync'].config.exclude.includes(`${configPrefix}.${key}`);
       if (shouldExclude) return;
 
+      // Do not export the _id field, as it is immutable
+      delete config._id;
+
       configs[`${configPrefix}.${key}`] = { key, value: JSON.parse(value), ...config };
     });
 

--- a/services/role-permissions.js
+++ b/services/role-permissions.js
@@ -120,6 +120,9 @@ module.exports = {
       // Check if the config should be excluded.
       const shouldExclude = strapi.plugins['config-sync'].config.exclude.includes(`${configPrefix}.${config.type}`);
       if (shouldExclude) return;
+      
+      // Do not export the _id field, as it is immutable
+      delete config._id;
 
       configs[`${configPrefix}.${config.type}`] = config;
     });

--- a/services/webhooks.js
+++ b/services/webhooks.js
@@ -89,6 +89,9 @@ module.exports = {
       // Check if the config should be excluded.
       const shouldExclude = strapi.plugins['config-sync'].config.exclude.includes(`${configPrefix}.${config.id}`);
       if (shouldExclude) return;
+      
+      // Do not export the _id field, as it is immutable
+      delete config._id;
 
       configs[`${configPrefix}.${config.id}`] = config;
     });


### PR DESCRIPTION
Hi,

The __id_ field causes the following error when using  MongoDB as a database:
```
(node:63) UnhandledPromiseRejectionWarning: MongoError: Performing an update on the path '_id' would modify the immutable field '_id'
```

This pull request addresses this issue by removing the __id_ key from exported configs.
I don't know if this issue affects other DB engines.
It might be interesting to handle each engine differently.