### PR TITLE
Fix README.md default settings not having some commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ In the example below you can see how, and also what the default settings are.
 	      importOnBootstrap: false,
 	      include: [
 	        "core-store",
-	        "user-role"
-	        "admin-role"
-	        "i18n-locale"
+	        "user-role",
+	        "admin-role",
+	        "i18n-locale",
 	      ],
 	      exclude: [
 	        "core-store.plugin_users-permissions_grant"


### PR DESCRIPTION
Hi! This is a great strapi plugin!
I was just using it and found a documentation fix I would like to contribute.

### What does it do?

Minor documentation fix on README.md