### PR TITLE
Gracefully warn about corrupt data

### DIFF
--- a/server/config/type.js
+++ b/server/config/type.js
@@ -183,6 +183,12 @@ const ConfigType = class ConfigType {
     await Promise.all(Object.values(AllConfig).map(async (config) => {
       const combinedUid = getCombinedUid(this.uidKeys, config);
       const combinedUidWhereFilter = getCombinedUidWhereFilter(this.uidKeys, config);
+
+      if (!combinedUid) {
+        strapi.log.warn(logMessage(`Missing data for entity with id ${config.id} of type ${this.configPrefix}`));
+        return;
+      }
+
       // Check if the config should be excluded.
       const shouldExclude = !isEmpty(strapi.config.get('plugin.config-sync.excludedConfig').filter((option) => `${this.configPrefix}.${combinedUid}`.startsWith(option)));
       if (shouldExclude) return;

--- a/server/services/main.js
+++ b/server/services/main.js
@@ -4,6 +4,7 @@ const { isEmpty } = require('lodash');
 const fs = require('fs');
 const util = require('util');
 const difference = require('../utils/getObjectDiff');
+const { logMessage } = require('../utils');
 
 /**
  * Main services for config import/export.
@@ -118,6 +119,12 @@ module.exports = () => ({
         }
 
         const fileContents = await strapi.plugin('config-sync').service('main').readConfigFile(type, name);
+
+        if (!fileContents) {
+          strapi.log.warn(logMessage(`An empty config file '${file}' was found in the sync directory`));
+          return;
+        }
+
         fileConfigs[`${type}.${formattedName}`] = fileContents;
       }));
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

When a record does not have all the required attributes, which means we cannot create a valid UID for it, we should exclude it from the sync process.

Also this PR will register a warning in the Strapi logs which notifies you about the entity not having all the required data.

### Why is it needed?

So that when there is a corrupt record in the database the plugin will not fail on you, but will just notify you about it.

### How to test it?

Install the PR in your Strapi project like so:

```
yarn add boazpoolman/strapi-plugin-config-sync#pull/52/head
npm install boazpoolman/strapi-plugin-config-sync#pull/52/head
```

### Related issue(s)/PR(s)

#51 
