### PR TITLE
feat(CLI): Exit with 1 when diff is not empty.

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -102,6 +102,7 @@ yarn.lock
 
 testApp
 coverage
+/config/sync
 
 ############################
 # Strapi

--- a/playground/__tests__/cli.test.js
+++ b/playground/__tests__/cli.test.js
@@ -6,6 +6,13 @@ const exec = util.promisify(require('child_process').exec);
 jest.setTimeout(20000);
 
 describe('Test the config-sync CLI', () => {
+
+  afterAll(async () => {
+    // Remove the generated files and the DB.
+    await exec('rm -rf config/sync');
+    await exec('rm -rf .tmp');
+  });
+
   test('Export', async () => {
     const { stdout } = await exec('yarn cs export -y');
     expect(stdout).toContain('Finished export');

--- a/playground/__tests__/cli.test.js
+++ b/playground/__tests__/cli.test.js
@@ -26,4 +26,16 @@ describe('Test the config-sync CLI', () => {
     const { stdout } = await exec('yarn cs diff');
     expect(stdout).toContain('No differences between DB and sync directory');
   });
+  test('Non-empty diff returns 1', async () => {
+    await exec('rm -rf config/sync/admin-role.strapi-author.json');
+    // Work around Jest not supporting custom error matching.
+    // https://github.com/facebook/jest/issues/8140
+    let error;
+    try {
+      await exec('yarn cs diff');
+    } catch(e) {
+     error = e;
+    }
+    expect(error).toHaveProperty('code', 1);
+  });
 });

--- a/playground/package.json
+++ b/playground/package.json
@@ -19,7 +19,7 @@
     "@strapi/plugin-users-permissions": "^4.0.0",
     "@strapi/strapi": "^4.0.0",
     "sqlite3": "5.0.2",
-    "strapi-plugin-config-sync": "boazpoolman/strapi-plugin-config-sync"
+    "strapi-plugin-config-sync": "./.."
   },
   "author": {
     "name": "A Strapi developer"

--- a/server/cli.js
+++ b/server/cli.js
@@ -269,7 +269,7 @@ program
         { color: true },
       ));
 
-      process.exit(0);
+      process.exit(1);
     }
 
     // Init table.
@@ -283,7 +283,7 @@ program
     // Print table.
     console.log(table.toString());
 
-    process.exit(0);
+    process.exit(1);
   });
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
To make it easier to use the diff command in scripts and CI and to align
its API with POSIX diff and diffs on most systems exit with 1 when the
diff is not empty. Keep exiting with 0 when it is.

Fixes #66.

I wanted to add tests but didn't find any except in the playground sub-project. However I wasn't successful running them. Executing `yarn test:unit` in the root of the repo fails with `error Command "cs" not found.` and the sub-project doesn't offer any test scripts in its `package.json`. Let me know, if I'm doing something wrong here.
