### PR TITLE
feat: Addition of the 'soft' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ Use this flag to sync a specific set of configs by giving the CLI a comma-separa
 ```bash
 [command] --partial user-role.public,i18n-locale.en
 ```
+
+##### Flag: `-f`, `--force`
+
+If you're using the soft setting to gracefully import config, you can use this flag to ignore the setting for the current command and forcefully import all changes anyway.
+
+```bash
+[command] --force
+```
+
 ### ↔️ Diff
 
 > _Command:_ `diff` | _Alias:_ `d`
@@ -342,6 +351,7 @@ In the example below you can see how, and also what the default settings are.
 	    config: {
 	      syncDir: "config/sync/",
 	      minify: false,
+	      soft: false,
 	      importOnBootstrap: false,
 	      customTypes: [],
 	      excludedTypes: [],
@@ -366,6 +376,14 @@ The path for reading and writing the sync files.
 When enabled all the exported JSON files will be minified.
 
 ###### Key: `minify`
+
+> `required:` NO | `type:` bool | `default:` `false`
+
+### Soft
+
+When enabled the import action will be limited to only create new entries. Entries to be deleted, or updated will be skipped from the import process and will remain in it's original state.
+
+###### Key: `soft`
 
 > `required:` NO | `type:` bool | `default:` `false`
 

--- a/admin/src/components/ActionButtons/index.js
+++ b/admin/src/components/ActionButtons/index.js
@@ -37,7 +37,7 @@ const ActionButtons = () => {
         isOpen={modalIsOpen}
         onClose={closeModal}
         type={actionType}
-        onSubmit={() => actionType === 'import' ? dispatch(importAllConfig(partialDiff, toggleNotification)) : dispatch(exportAllConfig(partialDiff, toggleNotification))}
+        onSubmit={(force) => actionType === 'import' ? dispatch(importAllConfig(partialDiff, force, toggleNotification)) : dispatch(exportAllConfig(partialDiff, toggleNotification))}
       />
     </ActionButtonsStyling>
   );

--- a/admin/src/components/ConfirmModal/index.js
+++ b/admin/src/components/ConfirmModal/index.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 
 import {
   Dialog,
@@ -9,10 +10,15 @@ import {
   Typography,
   Stack,
   Button,
+  Checkbox,
+  Divider,
+  Box,
 } from '@strapi/design-system';
 import { ExclamationMarkCircle } from '@strapi/icons';
 
 const ConfirmModal = ({ isOpen, onClose, onSubmit, type }) => {
+  const soft = useSelector((state) => state.getIn(['config', 'appEnv', 'config', 'soft'], false));
+  const [force, setForce] = useState(false);
   const { formatMessage } = useIntl();
 
   if (!isOpen) return null;
@@ -33,6 +39,21 @@ const ConfirmModal = ({ isOpen, onClose, onSubmit, type }) => {
           </Flex>
         </Stack>
       </DialogBody>
+      {(soft && type === 'import') && (
+        <React.Fragment>
+          <Divider />
+          <Box padding={4}>
+            <Checkbox
+              onValueChange={(value) => setForce(value)}
+              value={force}
+              name="force"
+              hint="Check this to ignore the soft setting."
+            >
+              {formatMessage({ id: 'config-sync.popUpWarning.force' })}
+            </Checkbox>
+          </Box>
+        </React.Fragment>
+      )}
       <DialogFooter
         startAction={(
           <Button
@@ -49,7 +70,7 @@ const ConfirmModal = ({ isOpen, onClose, onSubmit, type }) => {
             variant="secondary"
             onClick={() => {
               onClose();
-              onSubmit();
+              onSubmit(force);
             }}
           >
             {formatMessage({ id: `config-sync.popUpWarning.button.${type}` })}

--- a/admin/src/containers/ConfigPage/index.js
+++ b/admin/src/containers/ConfigPage/index.js
@@ -18,7 +18,7 @@ const ConfigPage = () => {
   const dispatch = useDispatch();
   const isLoading = useSelector((state) => state.getIn(['config', 'isLoading'], Map({})));
   const configDiff = useSelector((state) => state.getIn(['config', 'configDiff'], Map({})));
-  const appEnv = useSelector((state) => state.getIn(['config', 'appEnv']));
+  const appEnv = useSelector((state) => state.getIn(['config', 'appEnv', 'env']));
 
   useEffect(() => {
     dispatch(getAllConfigDiff(toggleNotification));

--- a/admin/src/state/actions/Config.js
+++ b/admin/src/state/actions/Config.js
@@ -55,13 +55,16 @@ export function exportAllConfig(partialDiff, toggleNotification) {
   };
 }
 
-export function importAllConfig(partialDiff, toggleNotification) {
+export function importAllConfig(partialDiff, force, toggleNotification) {
   return async function(dispatch) {
     dispatch(setLoadingState(true));
     try {
       const { message } = await request('/config-sync/import', {
         method: 'POST',
-        body: partialDiff,
+        body: {
+          force,
+          config: partialDiff,
+        }
       });
       toggleNotification({ type: 'success', message });
       dispatch(getAllConfigDiff(toggleNotification));
@@ -84,10 +87,10 @@ export function setLoadingState(value) {
 export function getAppEnv(toggleNotification) {
   return async function(dispatch) {
     try {
-      const { env } = await request('/config-sync/app-env', {
+      const envVars = await request('/config-sync/app-env', {
         method: 'GET',
       });
-      dispatch(setAppEnvInState(env));
+      dispatch(setAppEnvInState(envVars));
     } catch (err) {
       toggleNotification({ type: 'warning', message: { id: 'notification.error' } });
     }

--- a/admin/src/state/reducers/Config/index.js
+++ b/admin/src/state/reducers/Config/index.js
@@ -16,7 +16,7 @@ const initialState = fromJS({
   configDiff: Map({}),
   partialDiff: List([]),
   isLoading: false,
-  appEnv: 'development',
+  appEnv: Map({}),
 });
 
 export default function configReducer(state = initialState, action) {

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -6,6 +6,7 @@
   "popUpWarning.button.import": "Yes, import",
   "popUpWarning.button.export": "Yes, export",
   "popUpWarning.button.cancel": "Cancel",
+  "popUpWarning.force": "Force",
 
   "Header.Title": "Config Sync",
   "Header.Description": "Manage your database config across environments.",

--- a/server/cli.js
+++ b/server/cli.js
@@ -95,7 +95,7 @@ const getConfigState = (diff, configName, syncType) => {
   }
 };
 
-const handleAction = async (syncType, skipConfirm, configType, partials) => {
+const handleAction = async (syncType, skipConfirm, configType, partials, force) => {
   const app = await getStrapiApp();
   const hasSyncDir = fs.existsSync(app.config.get('plugin.config-sync.syncDir'));
 
@@ -173,7 +173,7 @@ const handleAction = async (syncType, skipConfirm, configType, partials) => {
             && warnings.delete[name]
           ) warning = warnings.delete[name];
 
-          await app.plugin('config-sync').service('main').importSingleConfig(name, onSuccess);
+          await app.plugin('config-sync').service('main').importSingleConfig(name, onSuccess, force);
           if (warning) console.log(`${chalk.yellow.bold('[warning]')} ${warning}`);
         }));
         console.log(`${chalk.green.bold('[success]')} Finished import`);
@@ -221,9 +221,10 @@ program
   .option('-t, --type <type>', 'The type of config')
   .option('-p, --partial <partials>', 'A comma separated string of configs')
   .option('-y, --yes', 'Skip the confirm prompt')
+  .option('-f, --force', 'Ignore the soft setting')
   .description('Import the config')
-  .action(async ({ yes, type, partial }) => {
-    return handleAction('import', yes, type, partial);
+  .action(async ({ yes, type, partial, force }) => {
+    return handleAction('import', yes, type, partial, force);
   });
 
 // `$ config-sync export`

--- a/server/config.js
+++ b/server/config.js
@@ -4,6 +4,7 @@ module.exports = {
   default: {
     syncDir: "config/sync/",
     minify: false,
+    soft: false,
     importOnBootstrap: false,
     customTypes: [],
     excludedTypes: [],

--- a/server/controllers/config.js
+++ b/server/controllers/config.js
@@ -45,16 +45,16 @@ module.exports = {
       return;
     }
 
-    if (!ctx.request.body) {
+    if (!ctx.request.body.config) {
       ctx.send({
-        message: 'No config was specified for the export endpoint.',
+        message: 'No config was specified for the import endpoint.',
       });
 
       return;
     }
 
-    await Promise.all(ctx.request.body.map(async (configName) => {
-      await strapi.plugin('config-sync').service('main').importSingleConfig(configName);
+    await Promise.all(ctx.request.body.config.map(async (configName) => {
+      await strapi.plugin('config-sync').service('main').importSingleConfig(configName, null, ctx.request.body.force);
     }));
 
     ctx.send({
@@ -89,6 +89,9 @@ module.exports = {
    * @returns {string} The current Strapi environment.
    */
   getAppEnv: async () => {
-    return { env: strapi.server.app.env };
+    return {
+      env: strapi.server.app.env,
+      config: strapi.config.get('plugin.config-sync'),
+    };
   },
 };

--- a/server/services/main.js
+++ b/server/services/main.js
@@ -214,9 +214,10 @@ module.exports = () => ({
    *
    * @param {string} configName - The name of the config file.
    * @param {object} onSuccess - Success callback to run on each single successfull import.
+   * @param {boolean} force - Ignore the soft setting.
    * @returns {void}
    */
-  importSingleConfig: async (configName, onSuccess) => {
+  importSingleConfig: async (configName, onSuccess, force) => {
     // Check if the config should be excluded.
     const shouldExclude = !isEmpty(strapi.config.get('plugin.config-sync.excludedConfig').filter((option) => configName.startsWith(option)));
     if (shouldExclude) return;
@@ -226,8 +227,8 @@ module.exports = () => ({
     const fileContents = await strapi.plugin('config-sync').service('main').readConfigFile(type, name);
 
     try {
-      await strapi.plugin('config-sync').types[type].importSingle(name, fileContents);
-      if (onSuccess) onSuccess(`${type}.${name}`);
+      const importState = await strapi.plugin('config-sync').types[type].importSingle(name, fileContents, force);
+      if (onSuccess && importState !== false) onSuccess(`${type}.${name}`);
     } catch (e) {
       throw new Error(`Error when trying to import ${type}.${name}. ${e}`);
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Implement a setting that will (if set to `true`) prevent deletion or updating of entries while importing.
When `true`, this setting will only create new entries in the db and leave the other config changes untouched.
It's a way of gracefully importing, making sure you will not lose changes you have made directly on a remote env.

### Why is it needed?

#74

### How to test it?

1. Install PR like so:
```
yarn add boazpoolman/strapi-plugin-config-sync#pull/78/head
npm install boazpoolman/strapi-plugin-config-sync#pull/78/head
```
2. Set the 'soft' setting to `true` through plugins config. See `README.md` in the PR.
3. Make the initial export if not allready done.
4. Make a change to a piece of config in the db. E.g. change some permissions of an existing role.
5. Import either through the GUI, or the CLI.

If all is correct the change listed for importing will be skipped and remain untouched.

6. Try now to force import to ignore the soft setting through the CLI with flag `-f` or through the GUI by clicking the `force` checkbox in the confirm modal before importing.

If all is correct the change listed for importing should now be imported regardless of the soft setting being set to `true`

### Related issue(s)/PR(s)

#74
