### PR TITLE
Fixing default for excludedConfig (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Specify the names of configs you want to exclude from the syncing process. By de
 
 ###### Key: `excludedConfig`
 
-> `required:` NO | `type:` array | `default:` `["core-store.plugin_users-permissions_grant"]`
+> `required:` NO | `type:` array | `default:` `['core-store.plugin_users-permissions_grant', 'core-store.plugin_upload_metrics']`
 
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -356,7 +356,8 @@ In the example below you can see how, and also what the default settings are.
 	      customTypes: [],
 	      excludedTypes: [],
 	      excludedConfig: [
-	        "core-store.plugin_users-permissions_grant"
+	        "core-store.plugin_users-permissions_grant",
+          "core-store.plugin_upload_metrics"
 	      ],
 	    },
 	  },


### PR DESCRIPTION
Hi, I noticed the default value for `excludedConfig` was updated in https://github.com/boazpoolman/strapi-plugin-config-sync/commit/4d44e03a18f5c525f7f76608a50583f2b66efe26

I also replaced double-quotes with single-quotes to match the lines above (e.g. line `413` is `excludedTypes: ['admin-role']`).

I hope this helps, thank you for your time and for maintaining this great tool.
