### PR TITLE
fix: lock the react-diff-viewer-continued dependency to 3.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "git-diff": "^2.0.6",
     "immutable": "^3.8.2",
     "inquirer": "^8.2.0",
-    "react-diff-viewer-continued": "^3.2.3",
+    "react-diff-viewer-continued": "3.2.6",
     "redux-immutable": "^4.0.0",
     "redux-thunk": "^2.3.0"
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Lock `react-diff-viewer-continued` to version `3.2.6`

### Why is it needed?

Because version `3.3.0` is faulty. See #105 

### How to test it?

For the latests commit on the master branch the error has been reproduced in the pipeline. See:
https://github.com/boazpoolman/strapi-plugin-config-sync/actions/runs/6551531539/job/17792933173

To test this PR we just have to see the the pipeline is successful.

### Related issue(s)/PR(s)
#105 
