### PR TITLE
fix: Remove recursive config sanitisation

### DIFF
--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -47,6 +47,11 @@ const dynamicSort = (property) => {
 };
 
 const sanitizeConfig = (config, relation, relationSortFields) => {
+  delete config._id;
+  delete config.id;
+  delete config.updatedAt;
+  delete config.createdAt;
+
   if (relation) {
     const formattedRelations = [];
 
@@ -68,20 +73,6 @@ const sanitizeConfig = (config, relation, relationSortFields) => {
 
     config[relation] = formattedRelations;
   }
-
-  const recursiveSanitizeConfig = (recursivedSanitizedConfig) => {
-    delete recursivedSanitizedConfig._id;
-    delete recursivedSanitizedConfig.id;
-    delete recursivedSanitizedConfig.updatedAt;
-    delete recursivedSanitizedConfig.createdAt;
-
-    Object.keys(recursivedSanitizedConfig).map((key, index) => {
-      if (recursivedSanitizedConfig[key] && typeof recursivedSanitizedConfig[key] === "object") {
-        recursiveSanitizeConfig(recursivedSanitizedConfig[key]);
-      }
-    });
-  };
-  recursiveSanitizeConfig(config);
 
   return config;
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

As of #93 all configuration files would be sanitized recursively.
That resulted in some unwanted behaviour (see #110) and turned out to be unnecessary.

This PR removes that recursive sanitisation.

### Why is it needed?

To solve #110

### How to test it?

1. Replicate #110
2. Update the plugin to make use of this PR:

```
yarn add boazpoolman/strapi-plugin-config-sync#pull/113/head
```

3. See the issue being fixed.
